### PR TITLE
Added support for a verify parameter (#5) to configure SSL certificate checking

### DIFF
--- a/rhnapi/system.py
+++ b/rhnapi/system.py
@@ -2884,7 +2884,7 @@ def setChildChannels(rhn, serverid, chanlist):
     chanlist([str])        - list of child channel labels
     """
     try:
-        return rhn.session.setChildChannels(rhn.key, serverid, chanlist) == 1
+        return rhn.session.system.setChildChannels(rhn.key, serverid, chanlist) == 1
     except Exception, E:
         return rhn.fail(E,'subscribe system %d to child channels [%s]' % (serverid, ','.join(chanlist)))
 


### PR DESCRIPTION
Allows to provide either a CA bundle file, a CA bundle directory or set to False. THe CA directory must be in the format of the python ssl library: https://docs.python.org/2/library/ssl.html#ssl.SSLContext.load_verify_locations